### PR TITLE
MOB-0 Allow customization of message

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ main-pain:
       uses: Humi-HR/main-pain@main
       with:
         slack-webhook-url: ${{ secrets.MAIN_PAIN_WEBHOOK_URL }}
+        message: '🚨 ALERT 🚨\n\nThe main branch of *${{ github.repository }}* is failing.\n\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}}}'
         details: 'Frontend Tests: ${{ needs.test-frontend.result }}\nBackend Tests: ${{ needs.test-backend.result }}'
         image-url: https://some-url/some-image.gif
 ```
@@ -31,5 +32,6 @@ main-pain:
 
 You must provide the `slack-webhook-url`.
 
+You can provide a message: a string of the main message to be sent.
 You can provide details: a string of additional details.
 You can provide image-url: a url to an image to be shown.

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   slack-webhook-url:
     description: "The webhook url to which this action should send the web request"
     required: true
+  message:
+    description: "The main notification message to be sent"
+    required: false
   details:
     description: "A string of additional details to be shown below the main notification"
     required: false
@@ -14,5 +17,5 @@ runs:
   using: "composite"
   steps:
     - run: |
-        curl -X POST -H 'Content-type: application/json' --data '{ "blocks": [ { "type": "section", "text": { "type": "mrkdwn", "text": "🚨 ALERT 🚨\n\nThe main branch of *${{ github.repository }}* is failing.\n\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" }, "accessory": { "type": "image", "image_url": "${{ inputs.image-url || 'https://media.giphy.com/media/gn5Zllp8hD2KY/giphy.gif' }}", "alt_text": "house on fire" } }, { "type": "section", "text": { "type": "mrkdwn", "text": "```Additional Details 📓\n\n${{ inputs.details || 'No additional details were provided.' }} ```" } }]  }' ${{ inputs.slack-webhook-url }}
+        curl -X POST -H 'Content-type: application/json' --data '{ "blocks": [ { "type": "section", "text": { "type": "mrkdwn", "text": "${{ inputs.message || '🚨 ALERT 🚨\n\nThe main branch of *${{ github.repository }}* is failing.\n\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}'}}" }, "accessory": { "type": "image", "image_url": "${{ inputs.image-url || 'https://media.giphy.com/media/gn5Zllp8hD2KY/giphy.gif' }}", "alt_text": "house on fire" } }, { "type": "section", "text": { "type": "mrkdwn", "text": "```Additional Details 📓\n\n${{ inputs.details || 'No additional details were provided.' }} ```" } }]  }' ${{ inputs.slack-webhook-url }}
       shell: bash


### PR DESCRIPTION
This change would simply allow consumers of the `main-pain` job to provide an alternative message to the default.

`🚨 ALERT 🚨\n\nThe main branch of *${{ github.repository }}* is failing.\n\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}}}`

In my case, I am trying to customize the message to something more mobile-specific. The default message was left in, so previous consumers should be unaffected.

This was tested using a manual curl first to confirm that the message changed:
![image](https://user-images.githubusercontent.com/104863080/207606805-8ae94089-31f4-4625-8eeb-bf3ad89ed87c.png)
