### PR TITLE
MOB-0 Add back missing info regarding message input

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ main-pain:
       uses: Humi-HR/main-pain@main
       with:
         slack-webhook-url: ${{ secrets.MAIN_PAIN_WEBHOOK_URL }}
+        message: '🚨 ALERT 🚨\n\nThe main branch of *${{ github.repository }}* is failing.\n\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}}}'
         details: 'Frontend Tests: ${{ needs.test-frontend.result }}\nBackend Tests: ${{ needs.test-backend.result }}'
         image-url: https://some-url/some-image.gif
 ```
@@ -31,5 +32,6 @@ main-pain:
 
 You must provide the `slack-webhook-url`.
 
+You can provide a message: a string of the main message to be sent.
 You can provide details: a string of additional details.
 You can provide image-url: a url to an image to be shown.

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   slack-webhook-url:
     description: "The webhook url to which this action should send the web request"
     required: true
+  message:
+    description: "The main notification message to be sent"
+    required: false
   details:
     description: "A string of additional details to be shown below the main notification"
     required: false


### PR DESCRIPTION
I realized when I reverted my original branch I forgot to add back the documentation and the definition for the `input` which was causing a warning message in our mobile E2E job since we were utilizing an undocumented input
![image](https://user-images.githubusercontent.com/104863080/209169126-fb165aff-d7a5-427e-b346-6a30be425489.png)
